### PR TITLE
Uefi acpi fix

### DIFF
--- a/boot/freeldr/freeldr/arch/uefi/uefihw.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefihw.c
@@ -24,6 +24,182 @@ extern ULONG VramSize;
 extern PCM_FRAMEBUF_DEVICE_DATA FrameBufferData;
 
 BOOLEAN AcpiPresent = FALSE;
+
+/**
+ * @brief Register an ISA bus in the hardware configuration tree.
+ *
+ * ScsiPort and other drivers use IoQueryDeviceDescription with
+ * InterfaceType=Isa to verify the bus exists before scanning.
+ */
+static
+VOID
+DetectIsaBus(
+    _In_ PCONFIGURATION_COMPONENT_DATA SystemKey,
+    _Inout_ PULONG BusNumber)
+{
+    PCM_PARTIAL_RESOURCE_LIST PartialResourceList;
+    PCONFIGURATION_COMPONENT_DATA BusKey;
+    ULONG Size;
+
+    Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors);
+    PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
+    if (!PartialResourceList)
+        return;
+
+    RtlZeroMemory(PartialResourceList, Size);
+    PartialResourceList->Version = 1;
+    PartialResourceList->Revision = 1;
+    PartialResourceList->Count = 0;
+
+    FldrCreateComponentKey(SystemKey,
+                           AdapterClass,
+                           MultiFunctionAdapter,
+                           0, 0, 0xFFFFFFFF,
+                           "ISA",
+                           PartialResourceList,
+                           Size,
+                           &BusKey);
+    (*BusNumber)++;
+}
+
+#define PCI_CONFIG_ADDRESS  0xCF8
+#define PCI_CONFIG_DATA     0xCFC
+
+/**
+ * @brief Detect PCI bus presence by probing config space mechanism 1
+ * and register the PCI bus in the hardware configuration tree.
+ *
+ * This replaces the BIOS INT 1Ah PCI detection for UEFI boots.
+ * PCI config mechanism 1 (I/O ports 0xCF8/0xCFC) is architecture-defined
+ * and works identically on BIOS and UEFI.
+ */
+static
+VOID
+DetectPci(
+    _In_ PCONFIGURATION_COMPONENT_DATA SystemKey,
+    _Inout_ PULONG BusNumber)
+{
+    PCI_REGISTRY_INFO BusData;
+    PCM_PARTIAL_RESOURCE_LIST PartialResourceList;
+    PCM_PARTIAL_RESOURCE_DESCRIPTOR PartialDescriptor;
+    PCONFIGURATION_COMPONENT_DATA BiosKey;
+    PCONFIGURATION_COMPONENT_DATA BusKey;
+    ULONG Size;
+    ULONG OldValue;
+    ULONG TestValue;
+    ULONG i;
+
+    /*
+     * Probe PCI configuration mechanism 1:
+     * Save old value at 0xCF8, write a known pattern, read back.
+     */
+    OldValue = __indword(PCI_CONFIG_ADDRESS);
+    __outdword(PCI_CONFIG_ADDRESS, 0x80000000);
+    TestValue = __indword(PCI_CONFIG_ADDRESS);
+    __outdword(PCI_CONFIG_ADDRESS, OldValue);
+
+    if (TestValue != 0x80000000)
+    {
+        TRACE("PCI mechanism 1 not detected (got 0x%lx)\n", TestValue);
+        return;
+    }
+
+    /* Read vendor ID at bus 0, device 0, function 0 to confirm PCI works */
+    __outdword(PCI_CONFIG_ADDRESS, 0x80000000);
+    TestValue = __indword(PCI_CONFIG_DATA);
+    if ((TestValue & 0xFFFF) == 0xFFFF)
+    {
+        TRACE("No PCI device at 0:0.0\n");
+        return;
+    }
+
+    TRACE("PCI mechanism 1 detected, host bridge vendor:device = %04lx:%04lx\n",
+          TestValue & 0xFFFF, (TestValue >> 16) & 0xFFFF);
+
+    /* Count PCI buses by scanning bus numbers for valid devices */
+    BusData.NoBuses = 1;
+    for (i = 1; i < 256; i++)
+    {
+        __outdword(PCI_CONFIG_ADDRESS, 0x80000000 | (i << 16));
+        TestValue = __indword(PCI_CONFIG_DATA);
+        if ((TestValue & 0xFFFF) != 0xFFFF)
+            BusData.NoBuses = (UCHAR)(i + 1);
+    }
+
+    BusData.MajorRevision = 2;
+    BusData.MinorRevision = 0;
+    BusData.HardwareMechanism = 1;
+
+    TRACE("Found %u PCI bus(es)\n", (ULONG)BusData.NoBuses);
+
+    /* Create the "PCI BIOS" MultiFunctionAdapter key (same as BIOS path) */
+    Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors);
+    PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
+    if (!PartialResourceList)
+        return;
+
+    RtlZeroMemory(PartialResourceList, Size);
+
+    FldrCreateComponentKey(SystemKey,
+                           AdapterClass,
+                           MultiFunctionAdapter,
+                           0,
+                           0,
+                           0xFFFFFFFF,
+                           "PCI BIOS",
+                           PartialResourceList,
+                           Size,
+                           &BiosKey);
+    (*BusNumber)++;
+
+    /* Report PCI buses */
+    for (i = 0; i < (ULONG)BusData.NoBuses; i++)
+    {
+        if (i == 0)
+        {
+            /* First bus gets the PCI_REGISTRY_INFO data */
+            Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors[1]) +
+                   sizeof(BusData);
+            PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
+            if (!PartialResourceList)
+                return;
+
+            RtlZeroMemory(PartialResourceList, Size);
+            PartialResourceList->Version = 1;
+            PartialResourceList->Revision = 1;
+            PartialResourceList->Count = 1;
+
+            PartialDescriptor = &PartialResourceList->PartialDescriptors[0];
+            PartialDescriptor->Type = CmResourceTypeDeviceSpecific;
+            PartialDescriptor->ShareDisposition = CmResourceShareUndetermined;
+            PartialDescriptor->u.DeviceSpecificData.DataSize = sizeof(BusData);
+
+            RtlCopyMemory(&PartialResourceList->PartialDescriptors[1],
+                          &BusData, sizeof(BusData));
+        }
+        else
+        {
+            Size = FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors);
+            PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
+            if (!PartialResourceList)
+                return;
+
+            RtlZeroMemory(PartialResourceList, Size);
+        }
+
+        FldrCreateComponentKey(SystemKey,
+                               AdapterClass,
+                               MultiFunctionAdapter,
+                               0,
+                               0,
+                               0xFFFFFFFF,
+                               "PCI",
+                               PartialResourceList,
+                               Size,
+                               &BusKey);
+        (*BusNumber)++;
+    }
+}
 static EFI_EVENT IdleTimerEvent = NULL;
 
 /* FUNCTIONS *****************************************************************/
@@ -344,8 +520,11 @@ UefiHwDetect(
 
     /* Detect buses */
     DetectInternal(SystemKey, &BusNumber);
-    // TODO: DetectPciBios
+    DetectPci(SystemKey, &BusNumber);
+    DetectIsaBus(SystemKey, &BusNumber);
     DetectAcpiBios(SystemKey, &BusNumber);
+
+    /* TODO: Detect ISA sub-devices (serial ports, keyboard, etc.) */
 
     TRACE("DetectHardware() Done\n");
     return SystemKey;

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -6,6 +6,8 @@
 
 #include "precomp.h"
 
+#include <arc/arc.h>
+#include <reactos/drivers/acpi/acpi.h>
 #include <pseh/pseh2.h>
 
 #define NDEBUG
@@ -16,6 +18,170 @@ static BOOLEAN AcpiInterruptHandlerRegistered = FALSE;
 static ACPI_OSD_HANDLER AcpiIrqHandler = NULL;
 static PVOID AcpiIrqContext = NULL;
 static ULONG AcpiIrqNumber = 0;
+extern NTSYSAPI PLOADER_PARAMETER_BLOCK KeLoaderBlock;
+extern NTSYSAPI
+PCONFIGURATION_COMPONENT_DATA
+NTAPI
+KeFindConfigurationNextEntry(
+    _In_ PCONFIGURATION_COMPONENT_DATA Child,
+    _In_ CONFIGURATION_CLASS Class,
+    _In_ CONFIGURATION_TYPE Type,
+    _In_opt_ PULONG ComponentKey,
+    _Inout_ PCONFIGURATION_COMPONENT_DATA *NextLink);
+
+static ACPI_TABLE_RSDP *AcpiLoaderRsdp = NULL;
+static ACPI_PHYSICAL_ADDRESS AcpiLoaderRsdpAddress = 0;
+
+static
+UCHAR
+AcpiChecksumBuffer(
+    _In_reads_bytes_(Length) const UCHAR *Buffer,
+    _In_ ULONG Length)
+{
+    ULONG Index;
+    UCHAR Sum;
+
+    Sum = 0;
+    for (Index = 0; Index < Length; ++Index)
+        Sum = (UCHAR)(Sum + Buffer[Index]);
+
+    return (UCHAR)(0 - Sum);
+}
+
+static
+PACPI_BIOS_MULTI_NODE
+AcpiGetLoaderAcpiBiosNode(VOID)
+{
+    PCONFIGURATION_COMPONENT_DATA ComponentEntry, Next;
+    PCM_PARTIAL_RESOURCE_LIST ResourceList;
+
+    if (!KeLoaderBlock || !KeLoaderBlock->ConfigurationRoot)
+        return NULL;
+
+    ComponentEntry = KeFindConfigurationNextEntry(KeLoaderBlock->ConfigurationRoot,
+                                                  AdapterClass,
+                                                  MultiFunctionAdapter,
+                                                  0,
+                                                  &Next);
+    while (ComponentEntry)
+    {
+        if ((ComponentEntry->ComponentEntry.Identifier != NULL) &&
+            !_stricmp(ComponentEntry->ComponentEntry.Identifier, "ACPI BIOS"))
+        {
+            break;
+        }
+
+        Next = ComponentEntry;
+        ComponentEntry = KeFindConfigurationNextEntry(KeLoaderBlock->ConfigurationRoot,
+                                                      AdapterClass,
+                                                      MultiFunctionAdapter,
+                                                      NULL,
+                                                      &Next);
+    }
+
+    if (!ComponentEntry)
+        return NULL;
+
+    ResourceList = ComponentEntry->ConfigurationData;
+    if (!ResourceList ||
+        (ComponentEntry->ComponentEntry.ConfigurationDataLength <
+         FIELD_OFFSET(CM_PARTIAL_RESOURCE_LIST, PartialDescriptors[1]) +
+         FIELD_OFFSET(ACPI_BIOS_MULTI_NODE, E820Entry)) ||
+        (ResourceList->Count < 1) ||
+        (ResourceList->PartialDescriptors[0].Type != CmResourceTypeDeviceSpecific))
+    {
+        DPRINT1("Loader ACPI BIOS node is missing valid device-specific data\n");
+        return NULL;
+    }
+
+    return (PACPI_BIOS_MULTI_NODE)(ResourceList + 1);
+}
+
+static
+ACPI_PHYSICAL_ADDRESS
+AcpiBuildLoaderRootPointer(VOID)
+{
+    PACPI_BIOS_MULTI_NODE NodeData;
+    ACPI_TABLE_HEADER *RootTable;
+    PHYSICAL_ADDRESS PhysicalAddress;
+
+    if (AcpiLoaderRsdpAddress != 0)
+        return AcpiLoaderRsdpAddress;
+
+    NodeData = AcpiGetLoaderAcpiBiosNode();
+    if (!NodeData || (NodeData->RsdtAddress.QuadPart == 0))
+        return 0;
+
+    RootTable = MmMapIoSpace(NodeData->RsdtAddress, sizeof(*RootTable), MmNonCached);
+    if (!RootTable)
+    {
+        DPRINT1("Unable to map loader ACPI root table at 0x%I64x\n",
+                NodeData->RsdtAddress.QuadPart);
+        return 0;
+    }
+
+    AcpiLoaderRsdp = ExAllocatePoolWithTag(NonPagedPool,
+                                           sizeof(*AcpiLoaderRsdp),
+                                           'dspR');
+    if (!AcpiLoaderRsdp)
+    {
+        MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+        DPRINT1("Unable to allocate synthetic RSDP for loader ACPI tables\n");
+        return 0;
+    }
+
+    RtlZeroMemory(AcpiLoaderRsdp, sizeof(*AcpiLoaderRsdp));
+    RtlCopyMemory(AcpiLoaderRsdp->Signature,
+                  ACPI_SIG_RSDP,
+                  sizeof(AcpiLoaderRsdp->Signature));
+    RtlCopyMemory(AcpiLoaderRsdp->OemId, "ROS   ", sizeof(AcpiLoaderRsdp->OemId));
+
+    if (RtlEqualMemory(RootTable->Signature, ACPI_SIG_XSDT, ACPI_NAMESEG_SIZE))
+    {
+        AcpiLoaderRsdp->Revision = 2;
+        AcpiLoaderRsdp->Length = sizeof(*AcpiLoaderRsdp);
+        AcpiLoaderRsdp->XsdtPhysicalAddress = NodeData->RsdtAddress.QuadPart;
+    }
+    else if (RtlEqualMemory(RootTable->Signature, ACPI_SIG_RSDT, ACPI_NAMESEG_SIZE))
+    {
+        if (NodeData->RsdtAddress.QuadPart > MAXULONG)
+        {
+            DPRINT1("Loader RSDT address does not fit in 32 bits: 0x%I64x\n",
+                    NodeData->RsdtAddress.QuadPart);
+            ExFreePoolWithTag(AcpiLoaderRsdp, 'dspR');
+            AcpiLoaderRsdp = NULL;
+            MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+            return 0;
+        }
+
+        AcpiLoaderRsdp->Revision = 0;
+        AcpiLoaderRsdp->RsdtPhysicalAddress = NodeData->RsdtAddress.LowPart;
+    }
+    else
+    {
+        DPRINT1("Loader ACPI root table has unexpected signature '%.4s'\n",
+                RootTable->Signature);
+        ExFreePoolWithTag(AcpiLoaderRsdp, 'dspR');
+        AcpiLoaderRsdp = NULL;
+        MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+        return 0;
+    }
+
+    AcpiLoaderRsdp->Checksum = AcpiChecksumBuffer((const UCHAR *)AcpiLoaderRsdp,
+                                                  ACPI_RSDP_CHECKSUM_LENGTH);
+    if (AcpiLoaderRsdp->Revision >= 2)
+    {
+        AcpiLoaderRsdp->ExtendedChecksum =
+            AcpiChecksumBuffer((const UCHAR *)AcpiLoaderRsdp,
+                               sizeof(*AcpiLoaderRsdp));
+    }
+
+    PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+    AcpiLoaderRsdpAddress = (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
+
+    MmUnmapIoSpace(RootTable, sizeof(*RootTable));
+    return AcpiLoaderRsdpAddress;
+}
 
 ACPI_STATUS
 AcpiOsInitialize (void)
@@ -46,6 +212,10 @@ AcpiOsGetRootPointer (
     ACPI_PHYSICAL_ADDRESS pa = 0;
 
     DPRINT("AcpiOsGetRootPointer\n");
+
+    pa = AcpiBuildLoaderRootPointer();
+    if (pa != 0)
+        return pa;
 
     AcpiFindRootPointer(&pa);
     return pa;
@@ -114,7 +284,7 @@ AcpiOsMapMemory (
 
     DPRINT("AcpiOsMapMemory(phys 0x%p  size 0x%X)\n", phys, length);
 
-    Address.QuadPart = (ULONG)phys;
+    Address.QuadPart = (ULONGLONG)phys;
     Ptr = MmMapIoSpace(Address, length, MmNonCached);
     if (!Ptr)
     {

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -30,7 +30,6 @@ KeFindConfigurationNextEntry(
     _Inout_ PCONFIGURATION_COMPONENT_DATA *NextLink);
 
 static ACPI_TABLE_RSDP *AcpiLoaderRsdp = NULL;
-static ACPI_PHYSICAL_ADDRESS AcpiLoaderRsdpAddress = 0;
 
 static
 UCHAR
@@ -105,8 +104,16 @@ AcpiBuildLoaderRootPointer(VOID)
     ACPI_TABLE_HEADER *RootTable;
     PHYSICAL_ADDRESS PhysicalAddress;
 
-    if (AcpiLoaderRsdpAddress != 0)
-        return AcpiLoaderRsdpAddress;
+    /*
+     * ACPICA may call us more than once during driver startup.
+     * Keep the synthetic RSDP alive and return the same physical
+     * address every time instead of rebuilding it.
+     */
+    if (AcpiLoaderRsdp != NULL)
+    {
+        PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+        return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
+    }
 
     NodeData = AcpiGetLoaderAcpiBiosNode();
     if (!NodeData || (NodeData->RsdtAddress.QuadPart == 0))
@@ -176,11 +183,9 @@ AcpiBuildLoaderRootPointer(VOID)
                                sizeof(*AcpiLoaderRsdp));
     }
 
-    PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
-    AcpiLoaderRsdpAddress = (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
-
     MmUnmapIoSpace(RootTable, sizeof(*RootTable));
-    return AcpiLoaderRsdpAddress;
+    PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+    return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
 }
 
 ACPI_STATUS

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -51,7 +51,8 @@ static
 PACPI_BIOS_MULTI_NODE
 AcpiGetLoaderAcpiBiosNode(VOID)
 {
-    PCONFIGURATION_COMPONENT_DATA ComponentEntry, Next;
+    PCONFIGURATION_COMPONENT_DATA ComponentEntry = NULL;
+    PCONFIGURATION_COMPONENT_DATA Next = NULL;
     PCM_PARTIAL_RESOURCE_LIST ResourceList;
 
     if (!KeLoaderBlock || !KeLoaderBlock->ConfigurationRoot)
@@ -187,8 +188,6 @@ ACPI_STATUS
 AcpiOsInitialize (void)
 {
     DPRINT("AcpiOsInitialize called\n");
-
-    AcpiBuildLoaderRootPointer();
 
 #ifndef NDEBUG
     /* Verboseness level of the acpica core */

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -60,7 +60,7 @@ AcpiGetLoaderAcpiBiosNode(VOID)
     ComponentEntry = KeFindConfigurationNextEntry(KeLoaderBlock->ConfigurationRoot,
                                                   AdapterClass,
                                                   MultiFunctionAdapter,
-                                                  0,
+                                                  NULL,
                                                   &Next);
     while (ComponentEntry)
     {
@@ -104,11 +104,6 @@ AcpiBuildLoaderRootPointer(VOID)
     ACPI_TABLE_HEADER *RootTable;
     PHYSICAL_ADDRESS PhysicalAddress;
 
-    /*
-     * ACPICA may call us more than once during driver startup.
-     * Keep the synthetic RSDP alive and return the same physical
-     * address every time instead of rebuilding it.
-     */
     if (AcpiLoaderRsdp != NULL)
     {
         PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
@@ -193,6 +188,8 @@ AcpiOsInitialize (void)
 {
     DPRINT("AcpiOsInitialize called\n");
 
+    AcpiBuildLoaderRootPointer();
+
 #ifndef NDEBUG
     /* Verboseness level of the acpica core */
     AcpiDbgLevel = 0x00FFFFFF;
@@ -215,8 +212,15 @@ AcpiOsGetRootPointer (
     void)
 {
     ACPI_PHYSICAL_ADDRESS pa = 0;
+    PHYSICAL_ADDRESS PhysicalAddress;
 
     DPRINT("AcpiOsGetRootPointer\n");
+
+    if (AcpiLoaderRsdp != NULL)
+    {
+        PhysicalAddress = MmGetPhysicalAddress(AcpiLoaderRsdp);
+        return (ACPI_PHYSICAL_ADDRESS)PhysicalAddress.QuadPart;
+    }
 
     pa = AcpiBuildLoaderRootPointer();
     if (pa != 0)

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -18,6 +18,9 @@ static BOOLEAN AcpiInterruptHandlerRegistered = FALSE;
 static ACPI_OSD_HANDLER AcpiIrqHandler = NULL;
 static PVOID AcpiIrqContext = NULL;
 static ULONG AcpiIrqNumber = 0;
+/* TODO: Replace these local declarations with <ndk/kefuncs.h> once the
+ * acpi.sys build context can consume the required NDK dependencies cleanly.
+ */
 extern NTSYSAPI PLOADER_PARAMETER_BLOCK KeLoaderBlock;
 extern NTSYSAPI
 PCONFIGURATION_COMPONENT_DATA

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -192,6 +192,8 @@ AcpiOsInitialize (void)
 {
     DPRINT("AcpiOsInitialize called\n");
 
+    AcpiBuildLoaderRootPointer();
+
 #ifndef NDEBUG
     /* Verboseness level of the acpica core */
     AcpiDbgLevel = 0x00FFFFFF;

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -20,6 +20,8 @@ Bus_PlugInDevice (
 #endif
 
 
+
+
 NTSTATUS
 NTAPI
 Bus_PnP (
@@ -282,19 +284,25 @@ Bus_StartFdo (
 
     AcpiStatus = AcpiInitializeSubsystem();
     if(ACPI_FAILURE(AcpiStatus)){
-        DPRINT1("Unable to AcpiInitializeSubsystem\n");
+        DPRINT1("Unable to AcpiInitializeSubsystem: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
         return STATUS_UNSUCCESSFUL;
     }
 
     AcpiStatus = AcpiInitializeTables(NULL, 16, 0);
     if (ACPI_FAILURE(AcpiStatus)){
-        DPRINT1("Unable to AcpiInitializeTables\n");
-		return STATUS_UNSUCCESSFUL;
+        DPRINT1("Unable to AcpiInitializeTables: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
+			return STATUS_UNSUCCESSFUL;
     }
 
     AcpiStatus = AcpiLoadTables();
     if(ACPI_FAILURE(AcpiStatus)){
-        DPRINT1("Unable to AcpiLoadTables\n");
+        DPRINT1("Unable to AcpiLoadTables: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
         AcpiTerminate();
         return STATUS_UNSUCCESSFUL;
     }
@@ -309,7 +317,9 @@ Bus_StartFdo (
     /* Initialize ACPI bus manager */
     AcpiStatus = acpi_init();
     if (!ACPI_SUCCESS(AcpiStatus)) {
-        DPRINT1("acpi_init() failed with status 0x%X\n", AcpiStatus);
+        DPRINT1("acpi_init() failed: %s (0x%08X)\n",
+                AcpiFormatException(AcpiStatus),
+                AcpiStatus);
         AcpiTerminate();
         return STATUS_UNSUCCESSFUL;
     }
@@ -596,5 +606,3 @@ DbgDeviceIDString(
 }
 
 #endif
-
-

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -19,9 +19,6 @@ Bus_PlugInDevice (
 #pragma alloc_text (PAGE, Bus_SendIrpSynchronously)
 #endif
 
-
-
-
 NTSTATUS
 NTAPI
 Bus_PnP (

--- a/drivers/bus/acpi/pnp.c
+++ b/drivers/bus/acpi/pnp.c
@@ -19,6 +19,7 @@ Bus_PlugInDevice (
 #pragma alloc_text (PAGE, Bus_SendIrpSynchronously)
 #endif
 
+
 NTSTATUS
 NTAPI
 Bus_PnP (


### PR DESCRIPTION
## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 

## Testbot runs (Filled in by Devs)

- [ ] KVM x86:
- [ ] KVM x64:

## Summary by Sourcery

Use loader-provided ACPI BIOS configuration to build a synthetic RSDP and improve ACPI initialization robustness and diagnostics.

Bug Fixes:
- Use 64-bit physical addresses when mapping ACPI memory to avoid truncation on 64-bit systems.
- Guard WOW64 pointer/handle cast macros with include-guards to prevent redefinition conflicts in WOW64 builds.

Enhancements:
- Derive the ACPI root pointer from the loader ACPI BIOS node and synthesize an RSDP structure when available, with checksum validation.
- Cache and reuse the synthesized loader RSDP in ACPI OSL root pointer retrieval.
- Improve ACPI subsystem startup logging by including human-readable ACPI error descriptions and status codes.